### PR TITLE
allow different "ignore_discard" value at save() time

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for HTTP-Cookies.  The HTTP::Cookies module used to be bundled
 with the libwww-perl distribution.
 
 {{$NEXT}}
+    - Add "ignore_discard" argument to save() methods
 
 6.04      2017-08-03 15:05:22Z
     - Fix package version numbers

--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -426,10 +426,16 @@ sub set_cookie
 sub save
 {
     my $self = shift;
-    my $file = shift || $self->{'file'} || return;
+    my %args = (
+        file => $self->{'file'},
+        ignore_discard => $self->{'ignore_discard'},
+        @_ == 1 ? ( file => $_[0] ) : @_
+    );
+    Carp::croak('Unexpected argument to save method') if keys %args > 2;
+    my $file = $args{'file'} || return;
     open(my $fh, '>', $file) or die "Can't open $file: $!";
     print {$fh} "#LWP-Cookies-1.0\n";
-    print {$fh} $self->as_string(!$self->{ignore_discard});
+    print {$fh} $self->as_string(!$args{'ignore_discard'});
     close $fh or die "Can't close $file: $!";
     1;
 }
@@ -736,11 +742,14 @@ various other attributes like "Comment" and "CommentURL".
 
 =item $cookie_jar->save( $file )
 
+=item $cookie_jar->save( file => $file, ignore_discard => $ignore_discard )
+
 This method file saves the state of the $cookie_jar to a file.
 The state can then be restored later using the load() method.  If a
 filename is not specified we will use the name specified during
-construction.  If the attribute I<ignore_discard> is set, then we
-will even save cookies that are marked to be discarded.
+construction.  If the $ignore_discard value is true (or not specified,
+but attribute I<ignore_discard> was set at cookie jar construction),
+then we will even save cookies that are marked to be discarded.
 
 The default is to save a sequence of "Set-Cookie3" lines.
 "Set-Cookie3" is a proprietary LWP format, not known to be compatible

--- a/lib/HTTP/Cookies/Netscape.pm
+++ b/lib/HTTP/Cookies/Netscape.pm
@@ -36,8 +36,14 @@ sub load
 
 sub save
 {
-    my($self, $file) = @_;
-    $file ||= $self->{'file'} || return;
+    my $self = shift;
+    my %args = (
+        file => $self->{'file'},
+        ignore_discard => $self->{'ignore_discard'},
+        @_ == 1 ? ( file => $_[0] ) : @_
+    );
+    Carp::croak('Unexpected argument to save method') if keys %args > 2;
+    my $file = $args{'file'} || return;
 
     open(my $fh, '>', $file) || return;
 
@@ -53,7 +59,7 @@ EOT
     my $now = time - $HTTP::Cookies::EPOCH_OFFSET;
     $self->scan(sub {
         my ($version, $key, $val, $path, $domain, $port, $path_spec, $secure, $expires, $discard, $rest) = @_;
-        return if $discard && !$self->{ignore_discard};
+        return if $discard && !$args{'ignore_discard'};
         $expires = $expires ? $expires - $HTTP::Cookies::EPOCH_OFFSET : 0;
         return if $now > $expires;
         $secure = $secure ? "TRUE" : "FALSE";

--- a/t/cookies.t
+++ b/t/cookies.t
@@ -1,7 +1,7 @@
 #!perl -w
 
 use Test;
-plan tests => 79, todo => [78, 79];
+plan tests => 79;
 
 use HTTP::Cookies;
 use HTTP::Request;

--- a/t/cookies.t
+++ b/t/cookies.t
@@ -1,7 +1,7 @@
 #!perl -w
 
 use Test;
-plan tests => 77;
+plan tests => 79, todo => [78, 79];
 
 use HTTP::Cookies;
 use HTTP::Request;
@@ -697,6 +697,38 @@ my @a = $c->get_cookies("example.com", "bar", "foo");
 ok(@a, 2);
 ok($a[0], undef);
 ok($a[1], 42);
+
+# Test ignore_discard argument of save()
+$c = HTTP::Cookies->new( ignore_discard => 0 );
+interact($c, 'http://example.com/', 'foo=bar; Discard;');
+$old = $c->as_string;
+$c->save( file => $file, ignore_discard => 1 );
+undef $c;
+
+$c = HTTP::Cookies->new( ignore_discard => 0 );
+$c->load($file);
+unlink($file) || warn "Can't unlink $file: $!";
+
+ok($c->as_string, $old);
+
+$c = HTTP::Cookies::Netscape->new( ignore_discard => 0 );
+$req = HTTP::Request->new(GET => "http://1.1.1.1/");
+$req->header("Host", "www.acme.com:80");
+$res = HTTP::Response->new(200, "OK");
+$res->request($req);
+$res->header("Set-Cookie" => "foo=bar; path=/; discard; expires=Wednesday, 09-Nov-$year_plus_one 23:12:40 GMT");
+$c->extract_cookies($res);
+$old = $c->as_string;
+$c->save( file => $file, ignore_discard => 1 );
+undef $c;
+
+$c = HTTP::Cookies::Netscape->new( ignore_discard => 0 );
+$c->load($file);
+$req = HTTP::Request->new(GET => "http://www.acme.com/foo/bar");
+$c->add_cookie_header($req);
+$h = $req->header("Cookie");
+ok($h =~ /foo=bar/);
+unlink($file) || warn "Can't unlink $file: $!";
 
 
 #-------------------------------------------------------------------


### PR DESCRIPTION
This change set provides the `save` method with an additional optional `ignore_discard` argument to override the value of the `ignore_discard` object attribute for this particular save operation.

Addresses [[rt.cpan.org #85011]](https://rt.cpan.org/Ticket/Display.html?id=85011).
