### PR TITLE
Test and document limitations

### DIFF
--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -655,7 +655,7 @@ to both store and retrieve information on the client side of the
 connection.  For more information about cookies refer to
 <URL:http://curl.haxx.se/rfc/cookie_spec.html> and
 <URL:http://www.cookiecentral.com/>.  This module also implements the
-new style cookies described in I<RFC 2965>.
+new style cookies described in L<RFC 2965|https://tools.ietf.org/html/rfc2965>.
 The two variants of cookies are supposed to be able to coexist happily.
 
 Instances of the class I<HTTP::Cookies> are able to store a collection

--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -664,6 +664,22 @@ information to initialize Cookie-headers in I<HTTP::Request> objects.
 The state of a I<HTTP::Cookies> object can be saved in and restored from
 files.
 
+=head1 LIMITATIONS
+
+This module does not support L<< Public Suffix|https://publicsuffix.org/
+>> encouraged by a more recent standard, L<< RFC
+6265|https://tools.ietf.org/html/rfc6265 >>.
+
+This module's shortcomings mean that a malicious Web site can set
+cookies to track your user agent across all sites under a top level
+domain.  See F<< t/publicsuffix.t >> in this module's distribution for
+details.
+
+L<< HTTP::CookieJar::LWP >> supports Public Suffix, but only provides a
+limited subset of this module's functionality and L<< does not
+support|HTTP::CookieJar/LIMITATIONS-AND-CAVEATS >> standards older than
+I<RFC 6265>.
+
 =head1 METHODS
 
 The following methods are provided:

--- a/t/publicsuffix.t
+++ b/t/publicsuffix.t
@@ -1,0 +1,74 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use HTTP::Cookies ();
+use HTTP::Date ();
+use HTTP::Request ();
+use HTTP::Response ();
+
+
+my $expiry_string = HTTP::Date::time2str( time + 86400 );
+my $jar = HTTP::Cookies->new;
+
+{
+    local $TODO = 'Unexpected cookies stored';
+    my $res = HTTP::Response->new( 200, 'OK' );
+    my $req = request_for('www.exceptone.co.uk');
+    $res->header( 'Set-Cookie' =>
+        "security=fail; Domain=.co.uk; Expires=${expiry_string}" );
+    $res->request($req);
+    $jar->extract_cookies($res);
+    is count_cookies_for('.co.uk'), 0, 'No .co.uk cookies stored in the jar';
+}
+
+{
+    local $TODO = 'Unexpected cookies stored';
+    my $req = request_for('www.google.co.uk');
+    $jar->add_cookie_header($req);
+    is $req->header('Cookie'), undef, 'No cookies sent to www.google.co.uk';
+}
+
+{
+    my $req = request_for('www.google.com');
+    $jar->add_cookie_header($req);
+    is $req->header('Cookie'), undef, 'No cookies sent to www.google.com';
+}
+
+{
+    local $TODO = 'Unexpected cookies stored';
+    my $res = HTTP::Response->new( 200, 'OK' );
+    my $req = request_for('www.example.com');
+    $res->header( 'Set-Cookie' =>
+        "dotcom=pwned; Domain=.com; Expires=${expiry_string}" );
+    $res->request($req);
+    $jar->extract_cookies($res);
+    is count_cookies_for('.com'), 0, 'No .com cookies stored in the jar';
+}
+
+{
+    local $TODO = 'Unexpected cookies stored';
+    my $req = request_for('www.google.com');
+    $jar->add_cookie_header($req);
+    is $req->header('Cookie'), undef, 'No cookies sent to www.google.com';
+}
+
+
+sub count_cookies_for {
+    my $host = shift;
+    my $count = 0;
+    $jar->scan( sub { $_[4] eq $host && $count++ });
+    return $count;
+}
+
+sub request_for {
+    my $host = shift;
+    my $req = HTTP::Request->new( GET => "http://${host}/");
+    $req->header( Host => $host );
+    return $req;
+}
+
+done_testing();


### PR DESCRIPTION
HTTP::Cookies does not support Public Suffix and allows servers to set cookies under a top level domain.  This change:
* includes TODO tests to demonstrate the problem
* documents the problem
* suggests HTTP::CookieJar::LWP as an alterative