### PR TITLE
fix broken README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 HTTP::Cookies - HTTP cookie jars
 
-[![Build Status](https://travis-ci.org/libwww-perl/http-cookies.png?branch=master)](https://travis-ci.org/libwww-perl/http-cookies)
+[![Build Status](https://travis-ci.org/libwww-perl/HTTP-Cookies.png?branch=master)](https://travis-ci.org/libwww-perl/HTTP-Cookies)
 
 # VERSION
 


### PR DESCRIPTION
The Travis CI badge in the README currently shows as:

[![Build Status](https://travis-ci.org/libwww-perl/http-cookies.png?branch=master)](https://travis-ci.org/libwww-perl/http-cookies)

This patch corrects the path so that the project is found and the badge shows as:

[![Build Status](https://travis-ci.org/libwww-perl/HTTP-Cookies.png?branch=master)](https://travis-ci.org/libwww-perl/HTTP-Cookies)