### PR TITLE
Make test pass in 2025

### DIFF
--- a/t/issue32.t
+++ b/t/issue32.t
@@ -7,12 +7,12 @@ use HTTP::Request;
 use HTTP::Response;
 
 my $req  = HTTP::Request->new(GET => "http://example.com");
-my $resp = HTTP::Response->new(200, 'OK', ['Set-Cookie', q!a="b;c;\\"d"; expires=Fri, 06-Nov-2025 08:58:34 GMT; domain=example.com; path=/!]);
+my $resp = HTTP::Response->new(200, 'OK', ['Set-Cookie', q!a="b;c;\\"d"; expires=Fri, 06-Nov-2999 08:58:34 GMT; domain=example.com; path=/!]);
 $resp->request($req);
 
 my $c = HTTP::Cookies->new;
 $c->extract_cookies($resp);
-is $c->as_string, 'Set-Cookie3: a="b;c;\"d"; path="/"; domain=example.com; path_spec; expires="2025-11-06 08:58:34Z"; version=0' . "\n";
+is $c->as_string, 'Set-Cookie3: a="b;c;\"d"; path="/"; domain=example.com; path_spec; expires="2999-11-06 08:58:34Z"; version=0' . "\n";
 
 # test the implementation of the split function in isolation.
 # should probably name the function better too.


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +15 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.