### PR TITLE
Fix t/issue32.t on old perl versions

### DIFF
--- a/t/issue32.t
+++ b/t/issue32.t
@@ -6,13 +6,15 @@ use HTTP::Cookies;
 use HTTP::Request;
 use HTTP::Response;
 
+my $nextyear = 1901+(gmtime())[5];
+
 my $req  = HTTP::Request->new(GET => "http://example.com");
-my $resp = HTTP::Response->new(200, 'OK', ['Set-Cookie', q!a="b;c;\\"d"; expires=Fri, 06-Nov-2999 08:58:34 GMT; domain=example.com; path=/!]);
+my $resp = HTTP::Response->new(200, 'OK', ['Set-Cookie', q!a="b;c;\\"d"; expires=Fri, 06-Nov-! . $nextyear . " 08:58:34 GMT; domain=example.com; path=/"]);
 $resp->request($req);
 
 my $c = HTTP::Cookies->new;
 $c->extract_cookies($resp);
-is $c->as_string, 'Set-Cookie3: a="b;c;\"d"; path="/"; domain=example.com; path_spec; expires="2999-11-06 08:58:34Z"; version=0' . "\n";
+is $c->as_string, 'Set-Cookie3: a="b;c;\"d"; path="/"; domain=example.com; path_spec; expires="' . $nextyear . '-11-06 08:58:34Z"; version=0' . "\n";
 
 # test the implementation of the split function in isolation.
 # should probably name the function better too.


### PR DESCRIPTION
perl < 5.12 had a year2038 bug, so instead we just use the next year as expiry
so that it will pass at least until 2036
and until then people should be on newer versions
and possibly even 64-bit platforms so that this will not be a problem.

This does not adjust the weekday, but apparently nobody checks it.

Fixes #58

Note: Only tested on newer perl and i586+x86\_64.