### PR TITLE
Netscape: allow HttpOnly cookies to be loaded

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for HTTP-Cookies.  The HTTP::Cookies module used to be bundled
 with the libwww-perl distribution.
 
 {{$NEXT}}
+    - Allow HttpOnly cookies to be loaded by HTTP::Cookies::Netscape (GH#63) (Charlie Hothersall-Thomas)
 
 6.08      2019-12-02 15:58:32Z
     - allow different "ignore_discard" value at save() time (GH#2) (Alex Peters)

--- a/lib/HTTP/Cookies/Netscape.pm
+++ b/lib/HTTP/Cookies/Netscape.pm
@@ -24,6 +24,7 @@ sub load
     my $now = time() - $HTTP::Cookies::EPOCH_OFFSET;
     while (my $line = <$fh>) {
         chomp($line);
+        $line =~ s/\s*\#HttpOnly_//;
         next if $line =~ /^\s*\#/;
         next if $line =~ /^\s*$/;
         $line =~ tr/\n\r//d;

--- a/t/cookies.t
+++ b/t/cookies.t
@@ -1,7 +1,7 @@
 #!perl -w
 
 use Test;
-plan tests => 79;
+plan tests => 80;
 
 use HTTP::Cookies;
 use HTTP::Request;
@@ -417,6 +417,10 @@ ok($c->as_string =~ /foo1=bar/);
 undef($c);
 unlink($file);
 
+# Expect a HttpOnly cookie to be loaded, rather than treated as a comment
+$c = HTTP::Cookies::Netscape->new(file => 't/data/netscape-httponly.txt');
+ok(count_cookies($c), 2);
+undef($c);
 
 #
 # Some additional Netscape cookies test

--- a/t/cookies.t
+++ b/t/cookies.t
@@ -419,7 +419,7 @@ unlink($file);
 
 # Expect a HttpOnly cookie to be loaded, rather than treated as a comment
 $c = HTTP::Cookies::Netscape->new(file => 't/data/netscape-httponly.txt');
-ok(count_cookies($c), 2);
+ok(count_cookies($c), 4);
 undef($c);
 
 #

--- a/t/data/netscape-httponly.txt
+++ b/t/data/netscape-httponly.txt
@@ -1,0 +1,6 @@
+# Netscape HTTP Cookie File
+# http://www.netscape.com/newsref/std/cookie_spec.html
+# This is a generated file!  Do not edit.
+
+www.acme.com	FALSE	/	FALSE	2147483647	foo1	bar
+#HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo2	bar

--- a/t/data/netscape-httponly.txt
+++ b/t/data/netscape-httponly.txt
@@ -2,5 +2,16 @@
 # http://www.netscape.com/newsref/std/cookie_spec.html
 # This is a generated file!  Do not edit.
 
+# Should be loaded as normal
 www.acme.com	FALSE	/	FALSE	2147483647	foo1	bar
+
+# Should be loaded with hostname www.acme.com
 #HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo2	bar
+ #HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo3	bar
+  #HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo4	bar
+
+# Should not be loaded (double prefix)
+#HttpOnly_#HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo5	bar
+
+# Should not be loaded (case-sensitivity)
+#Httponly_www.acme.com	FALSE	/	FALSE	2147483647	foo6	bar


### PR DESCRIPTION
Fixes #63, which contains all of the details.