### PR TITLE
Allow tests to pass after 2038

### DIFF
--- a/t/data/netscape-httponly.txt
+++ b/t/data/netscape-httponly.txt
@@ -3,15 +3,15 @@
 # This is a generated file!  Do not edit.
 
 # Should be loaded as normal
-www.acme.com	FALSE	/	FALSE	2147483647	foo1	bar
+www.acme.com	FALSE	/	FALSE	21474836470	foo1	bar
 
 # Should be loaded with hostname www.acme.com
-#HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo2	bar
- #HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo3	bar
-  #HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo4	bar
+#HttpOnly_www.acme.com	FALSE	/	FALSE	21474836470	foo2	bar
+ #HttpOnly_www.acme.com	FALSE	/	FALSE	21474836470	foo3	bar
+  #HttpOnly_www.acme.com	FALSE	/	FALSE	21474836470	foo4	bar
 
 # Should not be loaded (double prefix)
-#HttpOnly_#HttpOnly_www.acme.com	FALSE	/	FALSE	2147483647	foo5	bar
+#HttpOnly_#HttpOnly_www.acme.com	FALSE	/	FALSE	21474836470	foo5	bar
 
 # Should not be loaded (case-sensitivity)
-#Httponly_www.acme.com	FALSE	/	FALSE	2147483647	foo6	bar
+#Httponly_www.acme.com	FALSE	/	FALSE	21474836470	foo6	bar


### PR DESCRIPTION
Allow tests to pass after 2038
also tested on i586

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +16 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our package build.
See https://reproducible-builds.org/ for why this matters.

This patch was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).