### PR TITLE
Honour Max-Age when extracting cookies (GH#69)

### DIFF
--- a/Changes
+++ b/Changes
@@ -5,6 +5,9 @@ with the libwww-perl distribution.
     - Honour Max-Age when extracting cookies; it had been silently ignored
       since 6.10, so Max-Age=0 no longer deleted a cookie and a Max-Age
       lifetime was never applied (GH#69) (reported by Robert Mueller)
+    - When both Max-Age and Expires are present, let Max-Age take precedence
+      regardless of order, and let a repeated attribute's last value win, per
+      RFC 6265 5.3 (GH#69)
 
 6.11      2023-12-07 16:36:52Z
     - Replace "Test" with "Test::More" (GH#70) (James Raspass)

--- a/Changes
+++ b/Changes
@@ -2,6 +2,9 @@ Revision history for HTTP-Cookies.  The HTTP::Cookies module used to be bundled
 with the libwww-perl distribution.
 
 {{$NEXT}}
+    - Honour Max-Age when extracting cookies; it had been silently ignored
+      since 6.10, so Max-Age=0 no longer deleted a cookie and a Max-Age
+      lifetime was never applied (GH#69) (reported by Robert Mueller)
 
 6.11      2023-12-07 16:36:52Z
     - Replace "Test" with "Test::More" (GH#70) (James Raspass)

--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -210,6 +210,11 @@ sub extract_cookies {
         # field, so we have to use this ad-hoc parser.
         my $now = time();
 
+        # Far-future Expires dates and large Max-Age values are approximated
+        # at ten years out, to avoid overflowing time_t (or producing a float)
+        # when the expiry is serialized.
+        my $ten_years = 10 * 365 * 24 * 60 * 60;
+
         # Build a hash of cookies that was present in Set-Cookie2
         # headers.  We need to skip them if we also find them in a
         # Set-Cookie header.
@@ -263,7 +268,7 @@ sub extract_cookies {
 
                                 # the date is at least 10 years into the future, just replace
                                 # it with something approximate
-                                $expires_age = 10 * 365 * 24 * 60 * 60;
+                                $expires_age = $ten_years;
                             }
                         }
                     }
@@ -275,11 +280,9 @@ sub extract_cookies {
                     if ( defined $v && $v =~ /\A-?\d+\z/ ) {
 
                         # An absurdly large value would make time() + $max_age a
-                        # float in set_cookie and serialize to garbage. Cap it
-                        # with the same approximation the expires branch uses
-                        # for dates >= 10 years out.
-                        my $max = 10 * 365 * 24 * 60 * 60;
-                        $v = $max if $v > $max;
+                        # float in set_cookie and serialize to garbage, so cap
+                        # it at the same ten-year approximation used above.
+                        $v = $ten_years if $v > $ten_years;
 
                         # A later Max-Age overrides an earlier one (RFC 6265bis).
                         $max_age = $v;

--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -269,7 +269,20 @@ sub extract_cookies {
                     }
                 }
                 elsif ( !$first_param && lc($k) eq 'max-age' ) {
-                    $expires++;
+
+                    # RFC 6265 5.2.2: a non-integer Max-Age is ignored, not
+                    # treated as 0 (which would wrongly delete the cookie).
+                    if ( defined $v && $v =~ /\A-?\d+\z/ ) {
+
+                        # An absurdly large value would make time() + $maxage a
+                        # float in set_cookie and serialize to garbage. Cap it
+                        # with the same approximation the expires branch uses
+                        # for dates >= 10 years out.
+                        my $max = 10 * 365 * 24 * 60 * 60;
+                        $v = $max if $v > $max;
+                        push( @cur, "Max-Age" => $v );
+                        $expires++;
+                    }
                 }
                 elsif ( !$first_param
                     && lc($k) =~ /^(?:version|discard|ns-cookie)/ ) {

--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -224,6 +224,8 @@ sub extract_cookies {
             my @cur;
             my $param;
             my $expires;
+            my $maxage;         # Max-Age value, if seen (takes precedence)
+            my $expires_age;    # expiry secs from now (from an Expires attr)
             my $first_param = 1;
             for $param ( @{ _split_text($set) } ) {
                 next unless length($param);
@@ -239,10 +241,13 @@ sub extract_cookies {
                     #print "$k => undef";
                 }
                 if ( !$first_param && lc($k) eq "expires" ) {
+
+                    # Record the value rather than applying it now: a Max-Age
+                    # attribute, if present, takes precedence (RFC 6265 5.3), and
+                    # a later Expires overrides an earlier one.
                     my $etime = str2time($v);
                     if ( defined $etime ) {
-                        push( @cur, "Max-Age" => $etime - $now );
-                        $expires++;
+                        $expires_age = $etime - $now;
                     }
                     else {
                         # parse_date can deal with years outside the range of time_t,
@@ -251,19 +256,14 @@ sub extract_cookies {
                         if ($year) {
                             my $thisyear = (gmtime)[5] + 1900;
                             if ( $year < $thisyear ) {
-                                push( @cur, "Max-Age" => -1 )
-                                    ;    # any negative value will do
-                                $expires++;
+                                $expires_age
+                                    = -1;    # any negative value will do
                             }
                             elsif ( $year >= $thisyear + 10 ) {
 
                                 # the date is at least 10 years into the future, just replace
                                 # it with something approximate
-                                push(
-                                    @cur,
-                                    "Max-Age" => 10 * 365 * 24 * 60 * 60
-                                );
-                                $expires++;
+                                $expires_age = 10 * 365 * 24 * 60 * 60;
                             }
                         }
                     }
@@ -280,8 +280,9 @@ sub extract_cookies {
                         # for dates >= 10 years out.
                         my $max = 10 * 365 * 24 * 60 * 60;
                         $v = $max if $v > $max;
-                        push( @cur, "Max-Age" => $v );
-                        $expires++;
+
+                        # A later Max-Age overrides an earlier one (RFC 6265bis).
+                        $maxage = $v;
                     }
                 }
                 elsif ( !$first_param
@@ -296,6 +297,14 @@ sub extract_cookies {
             }
             next unless @cur;
             next if $in_set2{ $cur[0] };
+
+            # Apply the expiry once all params are parsed, with Max-Age taking
+            # precedence over Expires (RFC 6265 5.3).
+            my $age = defined $maxage ? $maxage : $expires_age;
+            if ( defined $age ) {
+                push( @cur, "Max-Age" => $age );
+                $expires++;
+            }
 
             #	    push(@cur, "Port" => $req_port);
             push( @cur, "Discard"   => undef ) unless $expires;

--- a/lib/HTTP/Cookies.pm
+++ b/lib/HTTP/Cookies.pm
@@ -224,7 +224,7 @@ sub extract_cookies {
             my @cur;
             my $param;
             my $expires;
-            my $maxage;         # Max-Age value, if seen (takes precedence)
+            my $max_age;        # Max-Age value, if seen (takes precedence)
             my $expires_age;    # expiry secs from now (from an Expires attr)
             my $first_param = 1;
             for $param ( @{ _split_text($set) } ) {
@@ -274,7 +274,7 @@ sub extract_cookies {
                     # treated as 0 (which would wrongly delete the cookie).
                     if ( defined $v && $v =~ /\A-?\d+\z/ ) {
 
-                        # An absurdly large value would make time() + $maxage a
+                        # An absurdly large value would make time() + $max_age a
                         # float in set_cookie and serialize to garbage. Cap it
                         # with the same approximation the expires branch uses
                         # for dates >= 10 years out.
@@ -282,7 +282,7 @@ sub extract_cookies {
                         $v = $max if $v > $max;
 
                         # A later Max-Age overrides an earlier one (RFC 6265bis).
-                        $maxage = $v;
+                        $max_age = $v;
                     }
                 }
                 elsif ( !$first_param
@@ -300,7 +300,7 @@ sub extract_cookies {
 
             # Apply the expiry once all params are parsed, with Max-Age taking
             # precedence over Expires (RFC 6265 5.3).
-            my $age = defined $maxage ? $maxage : $expires_age;
+            my $age = defined $max_age ? $max_age : $expires_age;
             if ( defined $age ) {
                 push( @cur, "Max-Age" => $age );
                 $expires++;

--- a/t/cookies.t
+++ b/t/cookies.t
@@ -828,7 +828,9 @@ $h = $req->header("Cookie");
 like( $h, qr/foo=bar/ );
 unlink($file) || warn "Can't unlink $file: $!";
 
-# Test discard isn't set when max-age is set
+# max-age must produce an expiry (GH #69); the cookie should be kept rather
+# than discarded. Match the expires value with a pattern, not a literal
+# timestamp, so the test does not depend on the current date.
 $c   = HTTP::Cookies->new;
 $req = HTTP::Request->new( "GET" => "http://example.com" );
 $res = HTTP::Response->new( 200, "OK" );
@@ -837,9 +839,11 @@ $res->header( "Set-Cookie" => "foo=bar; max-age=1337" );
 $c->extract_cookies($res);
 
 #print $c->as_string;
-is( $c->as_string, <<'EOT' );
-Set-Cookie3: foo=bar; path="/"; domain=example.com; version=0
-EOT
+like(
+    $c->as_string,
+    qr{^Set-Cookie3: foo=bar; path="/"; domain=example\.com; expires="[^"]+"; version=0\n\z},
+    "max-age sets an expiry and keeps the cookie"
+);
 
 #-------------------------------------------------------------------
 

--- a/t/issue69.t
+++ b/t/issue69.t
@@ -98,6 +98,8 @@ subtest 'a finite Max-Age wins over a far-future Expires' => sub {
     $jar->scan( sub { $expires = $_[8] } );
 
     ok defined $expires, 'cookie is stored with an expiry';
+    cmp_ok $expires, '>', time(), 'expiry is in the future'
+        if defined $expires;
     cmp_ok $expires, '<=', time() + 200,
         'the short Max-Age, not the 2099 Expires, controls the expiry'
         if defined $expires;

--- a/t/issue69.t
+++ b/t/issue69.t
@@ -55,7 +55,7 @@ subtest 'non-numeric Max-Age is ignored (RFC 6265 5.2.2)' => sub {
 };
 
 subtest 'an absurdly large Max-Age is capped at ~10 years' => sub {
-    # Without a cap, a huge value makes time() + $maxage a float, which
+    # Without a cap, a huge value makes time() + $max_age a float, which
     # serializes to garbage and silently downgrades to a session cookie.
     # Mirror the expires branch, which caps far-future dates at 10 years.
     my $ten_years = 10 * 365 * 24 * 60 * 60;

--- a/t/issue69.t
+++ b/t/issue69.t
@@ -1,0 +1,76 @@
+use strict;
+use warnings;
+use Test::More;
+
+use HTTP::Cookies  ();
+use HTTP::Request  ();
+use HTTP::Response ();
+
+# GH issue #69: the Max-Age attribute on a Set-Cookie header was parsed but
+# never carried through to the stored cookie, so Max-Age was completely
+# ignored -- cookies got no expiry and Max-Age=0 failed to delete them.
+
+sub jar_with_set_cookie {
+    my $set_cookie = shift;
+    my $req  = HTTP::Request->new( GET => 'http://example.com/' );
+    my $resp = HTTP::Response->new( 200, 'OK', [ 'Set-Cookie', $set_cookie ] );
+    $resp->request($req);
+    my $jar = HTTP::Cookies->new;
+    $jar->extract_cookies($resp);
+    return $jar;
+}
+
+subtest 'Max-Age sets a future expiry' => sub {
+    my $jar = jar_with_set_cookie(
+        'foo=bar; domain=example.com; path=/; Max-Age=3600');
+
+    my $expires;
+    $jar->scan( sub { $expires = $_[8] } );
+
+    ok defined $expires, 'cookie has an expiry derived from Max-Age';
+    cmp_ok $expires, '>', time(), 'expiry is in the future'
+        if defined $expires;
+};
+
+subtest 'Max-Age=0 deletes the cookie' => sub {
+    my $jar = jar_with_set_cookie(
+        'foo=bar; domain=example.com; path=/; Max-Age=0');
+
+    my $count = 0;
+    $jar->scan( sub { $count++ } );
+
+    is $count, 0, 'cookie with Max-Age=0 is not stored';
+};
+
+subtest 'non-numeric Max-Age is ignored (RFC 6265 5.2.2)' => sub {
+    # A malformed Max-Age must be ignored, not treated as 0. Treating it as 0
+    # would coerce the string to 0 in set_cookie and wrongly delete the cookie.
+    my $jar = jar_with_set_cookie(
+        'foo=bar; domain=example.com; path=/; Max-Age=not-a-number');
+
+    my $count = 0;
+    $jar->scan( sub { $count++ } );
+
+    is $count, 1, 'cookie with a non-numeric Max-Age is still stored';
+};
+
+subtest 'an absurdly large Max-Age is capped at ~10 years' => sub {
+    # Without a cap, a huge value makes time() + $maxage a float, which
+    # serializes to garbage and silently downgrades to a session cookie.
+    # Mirror the expires branch, which caps far-future dates at 10 years.
+    my $ten_years = 10 * 365 * 24 * 60 * 60;
+    my $jar = jar_with_set_cookie(
+        'foo=bar; domain=example.com; path=/; Max-Age=' . ( '9' x 30 ) );
+
+    my $expires;
+    $jar->scan( sub { $expires = $_[8] } );
+
+    ok defined $expires, 'cookie is stored with an expiry';
+    cmp_ok $expires, '>', time(), 'expiry is in the future'
+        if defined $expires;
+    cmp_ok $expires, '<=', time() + $ten_years + 10,
+        'huge Max-Age is capped at ~10 years, not a float overflow'
+        if defined $expires;
+};
+
+done_testing;

--- a/t/issue69.t
+++ b/t/issue69.t
@@ -73,4 +73,47 @@ subtest 'an absurdly large Max-Age is capped at ~10 years' => sub {
         if defined $expires;
 };
 
+subtest 'Max-Age takes precedence over Expires (RFC 6265 5.3)' => sub {
+    # Max-Age=0 must delete the cookie even when a far-future Expires is also
+    # present, regardless of the order the two attributes appear in.
+    for my $sc (
+        'foo=bar; domain=example.com; path=/; '
+          . 'expires=Thu, 01-Jan-2099 00:00:00 GMT; Max-Age=0',
+        'foo=bar; domain=example.com; path=/; '
+          . 'Max-Age=0; expires=Thu, 01-Jan-2099 00:00:00 GMT',
+    ) {
+        my $jar = jar_with_set_cookie($sc);
+        my $count = 0;
+        $jar->scan( sub { $count++ } );
+        is $count, 0, "Max-Age=0 wins over Expires ($sc)";
+    }
+};
+
+subtest 'a finite Max-Age wins over a far-future Expires' => sub {
+    my $jar = jar_with_set_cookie(
+        'foo=bar; domain=example.com; path=/; '
+          . 'expires=Thu, 01-Jan-2099 00:00:00 GMT; Max-Age=100');
+
+    my $expires;
+    $jar->scan( sub { $expires = $_[8] } );
+
+    ok defined $expires, 'cookie is stored with an expiry';
+    cmp_ok $expires, '<=', time() + 200,
+        'the short Max-Age, not the 2099 Expires, controls the expiry'
+        if defined $expires;
+};
+
+subtest 'the last Max-Age wins when repeated (RFC 6265bis 5.7)' => sub {
+    my $jar = jar_with_set_cookie(
+        'foo=bar; domain=example.com; path=/; Max-Age=1; Max-Age=5000');
+
+    my $expires;
+    $jar->scan( sub { $expires = $_[8] } );
+
+    ok defined $expires, 'cookie is stored with an expiry';
+    cmp_ok $expires, '>', time() + 1000,
+        'the later Max-Age (5000) controls the expiry, not the earlier (1)'
+        if defined $expires;
+};
+
 done_testing;

--- a/t/issue69.t
+++ b/t/issue69.t
@@ -12,8 +12,9 @@ use HTTP::Response ();
 
 sub jar_with_set_cookie {
     my $set_cookie = shift;
-    my $req  = HTTP::Request->new( GET => 'http://example.com/' );
-    my $resp = HTTP::Response->new( 200, 'OK', [ 'Set-Cookie', $set_cookie ] );
+    my $req        = HTTP::Request->new( GET => 'http://example.com/' );
+    my $resp
+        = HTTP::Response->new( 200, 'OK', [ 'Set-Cookie', $set_cookie ] );
     $resp->request($req);
     my $jar = HTTP::Cookies->new;
     $jar->extract_cookies($resp);
@@ -43,6 +44,7 @@ subtest 'Max-Age=0 deletes the cookie' => sub {
 };
 
 subtest 'non-numeric Max-Age is ignored (RFC 6265 5.2.2)' => sub {
+
     # A malformed Max-Age must be ignored, not treated as 0. Treating it as 0
     # would coerce the string to 0 in set_cookie and wrongly delete the cookie.
     my $jar = jar_with_set_cookie(
@@ -55,11 +57,12 @@ subtest 'non-numeric Max-Age is ignored (RFC 6265 5.2.2)' => sub {
 };
 
 subtest 'an absurdly large Max-Age is capped at ~10 years' => sub {
+
     # Without a cap, a huge value makes time() + $max_age a float, which
     # serializes to garbage and silently downgrades to a session cookie.
     # Mirror the expires branch, which caps far-future dates at 10 years.
     my $ten_years = 10 * 365 * 24 * 60 * 60;
-    my $jar = jar_with_set_cookie(
+    my $jar       = jar_with_set_cookie(
         'foo=bar; domain=example.com; path=/; Max-Age=' . ( '9' x 30 ) );
 
     my $expires;
@@ -74,15 +77,16 @@ subtest 'an absurdly large Max-Age is capped at ~10 years' => sub {
 };
 
 subtest 'Max-Age takes precedence over Expires (RFC 6265 5.3)' => sub {
+
     # Max-Age=0 must delete the cookie even when a far-future Expires is also
     # present, regardless of the order the two attributes appear in.
     for my $sc (
+          'foo=bar; domain=example.com; path=/; '
+        . 'expires=Thu, 01-Jan-2099 00:00:00 GMT; Max-Age=0',
         'foo=bar; domain=example.com; path=/; '
-          . 'expires=Thu, 01-Jan-2099 00:00:00 GMT; Max-Age=0',
-        'foo=bar; domain=example.com; path=/; '
-          . 'Max-Age=0; expires=Thu, 01-Jan-2099 00:00:00 GMT',
+        . 'Max-Age=0; expires=Thu, 01-Jan-2099 00:00:00 GMT',
     ) {
-        my $jar = jar_with_set_cookie($sc);
+        my $jar   = jar_with_set_cookie($sc);
         my $count = 0;
         $jar->scan( sub { $count++ } );
         is $count, 0, "Max-Age=0 wins over Expires ($sc)";
@@ -90,9 +94,8 @@ subtest 'Max-Age takes precedence over Expires (RFC 6265 5.3)' => sub {
 };
 
 subtest 'a finite Max-Age wins over a far-future Expires' => sub {
-    my $jar = jar_with_set_cookie(
-        'foo=bar; domain=example.com; path=/; '
-          . 'expires=Thu, 01-Jan-2099 00:00:00 GMT; Max-Age=100');
+    my $jar = jar_with_set_cookie( 'foo=bar; domain=example.com; path=/; '
+            . 'expires=Thu, 01-Jan-2099 00:00:00 GMT; Max-Age=100' );
 
     my $expires;
     $jar->scan( sub { $expires = $_[8] } );

--- a/t/issue69.t
+++ b/t/issue69.t
@@ -1,6 +1,6 @@
 use strict;
 use warnings;
-use Test::More;
+use Test::More 0.96;    # subtest
 
 use HTTP::Cookies  ();
 use HTTP::Request  ();


### PR DESCRIPTION
Closes #69

## Problem
Since 6.10 (GH#61, "do not set discard if max-age is set"), the `max-age`
branch in `extract_cookies` incremented the expiry counter but never pushed
the value onto `@cur`. As a result `set_cookie` always received an `undef`
max-age, so **Max-Age was completely ignored**: cookies received no expiry,
and `Max-Age=0` no longer deleted a cookie (a server-side logout/expiry
signal silently failed — CWE-613, Insufficient Session Expiration).

While fixing that, a second defect was found: both the `expires` and
`max-age` branches collapsed into the same `"Max-Age"` entry on `@cur`, and a
downstream first-wins dedup meant **header order** decided which applied. RFC
6265 §5.3 requires Max-Age to take precedence over Expires.

## Changes
- `lib/HTTP/Cookies.pm`:
  - Honour Max-Age: carry the parsed value through to `set_cookie`.
  - Ignore a non-integer Max-Age per RFC 6265 §5.2.2 (previously such a value
    coerced to `0` and wrongly deleted the cookie). Our regex also rejects a
    bare `-`, matching the stricter forthcoming 6265bis wording.
  - Cap an absurdly large Max-Age at ~10 years — the same approximation the
    sibling `expires` branch already uses — so `time() + maxage` cannot become
    a float that serializes to garbage.
  - Resolve expiry after parsing with **Max-Age taking precedence over
    Expires regardless of order**, and last-value-wins for a repeated
    attribute (RFC 6265 §5.3 / 6265bis §5.7). A malformed Max-Age now falls
    back to Expires instead of being treated as present-but-zero.
- `Changes`: changelog entries.

## Testing
- New `t/issue69.t`: future expiry, `Max-Age=0` deletion, non-integer
  ignored, large-value cap, Max-Age-over-Expires precedence in **both**
  orders, finite-Max-Age-over-far-future-Expires, and repeated-Max-Age
  last-wins. Each verified red→green (fails with the relevant fix reverted,
  passes with it).
- Updated the existing max-age test in `t/cookies.t`, which had asserted the
  buggy no-expiry output, to a date-independent pattern.
- Full suite green: `Tests=128, Result: PASS`.

## RFC backing (verbatim)
- §5.2.2: "If the first character of the attribute-value is not a DIGIT or a
  `-` character, ignore the cookie-av. If the remainder … contains a
  non-DIGIT character, ignore the cookie-av." … "If delta-seconds is less
  than or equal to zero (0), let expiry-time be the earliest representable
  date and time."
- §5.3: "If a cookie has both the Max-Age and the Expires attribute, the
  Max-Age attribute has precedence and controls the expiration date."

Note: the ~10-year cap is a pragmatic anti-overflow measure, not mandated by
the RFC.
